### PR TITLE
Add Books & Music routes with dark branding

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -146,6 +146,40 @@ export const Header = () => {
                   />
                 </>
               )}
+              {routes["/books"] && (
+                <>
+                  <ToggleButton
+                    className="s-flex-hide"
+                    prefixIcon="book"
+                    href="/books"
+                    label="Books"
+                    selected={pathname.startsWith("/books")}
+                  />
+                  <ToggleButton
+                    className="s-flex-show"
+                    prefixIcon="book"
+                    href="/books"
+                    selected={pathname.startsWith("/books")}
+                  />
+                </>
+              )}
+              {routes["/music"] && (
+                <>
+                  <ToggleButton
+                    className="s-flex-hide"
+                    prefixIcon="book"
+                    href="/music"
+                    label="Music"
+                    selected={pathname.startsWith("/music")}
+                  />
+                  <ToggleButton
+                    className="s-flex-show"
+                    prefixIcon="book"
+                    href="/music"
+                    selected={pathname.startsWith("/music")}
+                  />
+                </>
+              )}
               {display.themeSwitcher && (
                 <>
                   <Line background="neutral-alpha-medium" vert maxHeight="24" />

--- a/src/resources/once-ui.config.js
+++ b/src/resources/once-ui.config.js
@@ -9,6 +9,8 @@ const routes = {
   "/work": true,
   "/blog": true,
   "/gallery": true,
+  "/books": true,
+  "/music": true,
 };
 
 const display = {
@@ -60,10 +62,10 @@ const fonts = {
 
 // default customization applied to the HTML in the main layout.tsx
 const style = {
-  theme: "system", // dark | light | system
+  theme: "dark", // dark | light | system
   neutral: "gray", // sand | gray | slate | custom
-  brand: "cyan", // blue | indigo | violet | magenta | pink | red | orange | yellow | moss | green | emerald | aqua | cyan | custom
-  accent: "red", // blue | indigo | violet | magenta | pink | red | orange | yellow | moss | green | emerald | aqua | cyan | custom
+  brand: "blue", // blue | indigo | violet | magenta | pink | red | orange | yellow | moss | green | emerald | aqua | cyan | custom
+  accent: "indigo", // blue | indigo | violet | magenta | pink | red | orange | yellow | moss | green | emerald | aqua | cyan | custom
   solid: "contrast", // color | contrast
   solidStyle: "flat", // flat | plastic
   border: "playful", // rounded | playful | conservative


### PR DESCRIPTION
## Summary
- enable `/books` and `/music` routes
- switch theme to dark with blue branding and indigo accent
- show Books and Music links in the header when enabled

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68584467b13c832db6c57983eab8fa29