### PR TITLE
Add books and music pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,7 @@ git push origin main
 * **Once‑UI**: prefer high‑level primitives (`Column`, `Flex`, `Grid`); colors via design tokens.
 * **Images**: use Next `<Image />` unless inside `next/og` runtime code.
 * **Imports**: absolute (`@/components/…`) thanks to `tsconfig.paths`.
+* OG image routes live in `<page>/og/route.tsx` and use `next/og`'s `ImageResponse`.
 
 ---
 

--- a/src/app/books/TheLiminalCard.tsx
+++ b/src/app/books/TheLiminalCard.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Column, Flex, Heading, Media, SmartLink, Text } from '@once-ui-system/core';
+
+interface TheLiminalCardProps {
+  cover: string;
+  synopsis: string;
+  buyLink: string;
+  sampleLink: string;
+}
+
+export default function TheLiminalCard({
+  cover,
+  synopsis,
+  buyLink,
+  sampleLink,
+}: TheLiminalCardProps) {
+  return (
+    <Column gap="m" padding="24" radius="l" border="neutral-alpha-weak" fillWidth>
+      <Media src={cover} alt="The Liminal cover" aspectRatio="3/4" radius="l" />
+      <Heading as="h3" variant="heading-strong-m">
+        The Liminal
+      </Heading>
+      <Text variant="body-default-s" onBackground="neutral-weak">
+        {synopsis}
+      </Text>
+      <Flex gap="24" wrap>
+        <SmartLink href={buyLink} prefixIcon="book">
+          <Text variant="body-default-s">Buy</Text>
+        </SmartLink>
+        <SmartLink href={sampleLink} prefixIcon="document">
+          <Text variant="body-default-s">Sample</Text>
+        </SmartLink>
+      </Flex>
+    </Column>
+  );
+}

--- a/src/app/books/page.tsx
+++ b/src/app/books/page.tsx
@@ -1,0 +1,18 @@
+import { Column, Grid, Heading } from '@once-ui-system/core';
+import TheLiminalCard from './TheLiminalCard';
+
+export default function Books() {
+  return (
+    <Column maxWidth="m" gap="l">
+      <Heading variant="display-strong-s">Books</Heading>
+      <Grid columns="3" mobileColumns="1">
+        <TheLiminalCard
+          cover="/images/projects/project-01/image-01.jpg"
+          synopsis="A speculative fiction novel about crossing realities."
+          buyLink="#"
+          sampleLink="#"
+        />
+      </Grid>
+    </Column>
+  );
+}

--- a/src/app/books/the-liminal/og/route.tsx
+++ b/src/app/books/the-liminal/og/route.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable @next/next/no-img-element */
+import { ImageResponse } from 'next/og';
+import { baseURL } from '@/resources';
+
+export const runtime = 'edge';
+
+export async function GET() {
+  const cover = `${baseURL}/images/projects/project-01/cover-01.jpg`;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: 'flex',
+          width: '100%',
+          height: '100%',
+          background: '#151515',
+          color: '#fff',
+          fontSize: '64px',
+          padding: '40px',
+        }}
+      >
+        <img
+          src={cover}
+          alt="The Liminal cover"
+          style={{ width: '40%', height: '100%', objectFit: 'cover', borderRadius: '0.5rem' }}
+        />
+        <div
+          style={{
+            display: 'flex',
+            flex: 1,
+            paddingLeft: '40px',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <span style={{ fontWeight: 700 }}>The Liminal</span>
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+    }
+  );
+}

--- a/src/app/music/DreamingInHexCard.tsx
+++ b/src/app/music/DreamingInHexCard.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Column, Flex, Heading, Text, Tag } from '@once-ui-system/core';
+
+interface DreamingInHexCardProps {
+  embedUrl: string;
+  title: string;
+  year: string;
+  bpm: number;
+  tags: string[];
+}
+
+export default function DreamingInHexCard({
+  embedUrl,
+  title,
+  year,
+  bpm,
+  tags,
+}: DreamingInHexCardProps) {
+  return (
+    <Column gap="m" padding="24" radius="l" border="neutral-alpha-weak" fillWidth>
+      <div style={{ position: 'relative', paddingBottom: '120%', height: 0, width: '100%' }}>
+        <iframe
+          src={embedUrl}
+          style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: 0 }}
+          loading="lazy"
+        />
+      </div>
+      <Heading as="h3" variant="heading-strong-m">
+        {title}
+      </Heading>
+      <Text variant="label-default-s" onBackground="neutral-weak">
+        {year} · {bpm} BPM
+      </Text>
+      <Flex gap="8" wrap>
+        {tags.map((tag) => (
+          <Tag key={tag} label={tag} variant="neutral" />
+        ))}
+      </Flex>
+    </Column>
+  );
+}

--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -1,0 +1,19 @@
+import { Column, Grid, Heading } from '@once-ui-system/core';
+import DreamingInHexCard from './DreamingInHexCard';
+
+export default function Music() {
+  return (
+    <Column maxWidth="m" gap="l">
+      <Heading variant="display-strong-s">Music</Heading>
+      <Grid columns="3" mobileColumns="1">
+        <DreamingInHexCard
+          embedUrl="https://bandcamp.com/EmbeddedPlayer/album=000/size=large"
+          title="Dreaming in Hex"
+          year="2024"
+          bpm={120}
+          tags={['synth', 'downtempo']}
+        />
+      </Grid>
+    </Column>
+  );
+}


### PR DESCRIPTION
## Summary
- add Books page and The Liminal card
- generate OG image for The Liminal
- add Music page with Dreaming in Hex card
- document OG route pattern in AGENTS

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685852ea1af8832db57c27964c9acf06