### PR TITLE
Add responsive project thumbnails and hero images

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,8 @@ import { Heading, Flex, Text, Button, Avatar, RevealFx, Column, Badge, Row, Meta
 import { home, about, person, newsletter, baseURL, routes } from "@/resources";
 import { Mailchimp } from "@/components";
 import { Projects } from "@/components/work/Projects";
+import ProjectPreview from "@/components/work/ProjectPreview";
+import { projects } from "@/data/projects";
 import { Posts } from "@/components/blog/Posts";
 
 export default function Home() {
@@ -68,7 +70,7 @@ export default function Home() {
         </Column>
       </Column>
       <RevealFx translateY="16" delay={0.6}>
-        <Projects range={[1, 1]} />
+        <ProjectPreview project={projects[0]} />
       </RevealFx>
       {routes["/blog"] && (
         <Flex fillWidth gap="24" mobileDirection="column">

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -1,7 +1,9 @@
 import { notFound } from "next/navigation";
 import { getPosts } from "@/app/utils/utils";
-import { Meta, Schema, AvatarGroup, Button, Column, Flex, Heading, Media, Text } from "@once-ui-system/core";
+import { Meta, Schema, AvatarGroup, Button, Column, Flex, Heading, Text } from "@once-ui-system/core";
 import { baseURL, about, person, work } from "@/resources";
+import { projects } from "@/data/projects";
+import Image from "next/image";
 import { formatDate } from "@/app/utils/formatDate";
 import { ScrollToHash, CustomMDX } from "@/components";
 import { Metadata } from "next";
@@ -43,6 +45,8 @@ export default async function Project({
 
   let post = getPosts(["src", "app", "work", "projects"]).find((post) => post.slug === slugPath);
 
+  const projectMeta = projects.find((p) => p.slug === slugPath);
+
   if (!post) {
     notFound();
   }
@@ -75,13 +79,14 @@ export default async function Project({
         </Button>
         <Heading variant="display-strong-s">{post.metadata.title}</Heading>
       </Column>
-      {post.metadata.images.length > 0 && (
-        <Media
-          priority
-          aspectRatio="16 / 9"
-          radius="m"
-          alt="image"
-          src={post.metadata.images[0]}
+      {projectMeta && (
+        <Image
+          src={projectMeta.hero}
+          alt={`${post.metadata.title} hero image`}
+          width={1920}
+          height={1080}
+          sizes="(min-width:1024px) 70vw, 100vw"
+          className="w-full h-auto rounded-xl mb-6"
         />
       )}
       <Column style={{ margin: "auto" }} as="article" maxWidth="xs">

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,3 +8,4 @@ export { Providers } from "@/components/Providers";
 export { ScrollToHash } from "@/components/ScrollToHash";
 export { ThemeToggle } from "@/components/ThemeToggle";
 export { CustomMDX } from "@/components/mdx";
+export { default as ProjectPreview } from "@/components/work/ProjectPreview";

--- a/src/components/work/ProjectPreview.tsx
+++ b/src/components/work/ProjectPreview.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { Column, Heading, Text } from "@once-ui-system/core";
+import type { ProjectMeta } from "@/data/projects";
+
+interface ProjectPreviewProps {
+  project: ProjectMeta;
+}
+
+export default function ProjectPreview({ project }: ProjectPreviewProps) {
+  return (
+    <Link href={`/work/${project.slug}`} style={{ textDecoration: "none" }}>
+      <Column gap="12" fillWidth>
+        <Image
+          src={project.thumbnail}
+          alt="CleanMyDesktop Pro thumbnail"
+          width={768}
+          height={768}
+          sizes="(max-width: 768px) 100vw, 300px"
+          className="w-full max-w-[300px] h-auto rounded-xl shadow-lg"
+          priority
+        />
+        <Heading as="h3" variant="heading-strong-m">
+          {project.title}
+        </Heading>
+        <Text variant="body-default-s" onBackground="neutral-weak">
+          {project.summary}
+        </Text>
+      </Column>
+    </Link>
+  );
+}

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,24 @@
+export interface ProjectMeta {
+  slug: string;
+  title: string;
+  summary: string;
+  thumbnail: string;
+  hero: string;
+}
+
+export const projects: ProjectMeta[] = [
+  {
+    slug: 'cleanmydesktop-pro',
+    title: 'CleanMyDesktop Pro',
+    summary: 'One-click organizer for chaotic desktops.',
+    thumbnail: '/assets/projects/cleanmydesktop-pro/thumb@1x1.jpg',
+    hero: '/assets/projects/cleanmydesktop-pro/hero@16x9.jpg',
+  },
+  {
+    slug: 'habit-tracker',
+    title: 'Habit Tracker',
+    summary: 'Track daily habits with ease.',
+    thumbnail: '/assets/projects/habit-tracker/thumb@1x1.jpg',
+    hero: '/assets/projects/habit-tracker/hero@16x9.jpg',
+  },
+];


### PR DESCRIPTION
## Summary
- add structured project data with hero/thumbnail
- show featured project preview on homepage
- include hero image on project pages
- expose `ProjectPreview` via component index

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6858ac130ee8832d81e7c1414b42c0a7