### PR TITLE
Add Habit Tracker project metadata and hero

### DIFF
--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -1,10 +1,12 @@
 import { notFound } from "next/navigation";
 import { getPosts } from "@/app/utils/utils";
-import { Meta, Schema, AvatarGroup, Button, Column, Flex, Heading, Media, Text } from "@once-ui-system/core";
+import { Meta, Schema, AvatarGroup, Button, Column, Flex, Heading, Text } from "@once-ui-system/core";
+import Image from "next/image";
 import { baseURL, about, person, work } from "@/resources";
 import { formatDate } from "@/app/utils/formatDate";
 import { ScrollToHash, CustomMDX } from "@/components";
 import { Metadata } from "next";
+import { projects as projectMeta } from "@/data/projects";
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
   const posts = getPosts(["src", "app", "work", "projects"]);
@@ -51,6 +53,7 @@ export default async function Project({
     post.metadata.team?.map((person) => ({
       src: person.avatar,
     })) || [];
+  const meta = projectMeta.find((p) => p.slug === post.slug);
 
   return (
     <Column as="section" maxWidth="m" horizontal="center" gap="l">
@@ -75,13 +78,15 @@ export default async function Project({
         </Button>
         <Heading variant="display-strong-s">{post.metadata.title}</Heading>
       </Column>
-      {post.metadata.images.length > 0 && (
-        <Media
+      {meta && (
+        <Image
           priority
-          aspectRatio="16 / 9"
-          radius="m"
-          alt="image"
-          src={post.metadata.images[0]}
+          src={meta.hero}
+          alt={`${meta.title} hero`}
+          width={1600}
+          height={900}
+          sizes="(min-width:1024px) 70vw, 100vw"
+          className="w-full h-auto rounded-xl mb-6"
         />
       )}
       <Column style={{ margin: "auto" }} as="article" maxWidth="xs">

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -2,13 +2,13 @@
 
 import {
   AvatarGroup,
-  Carousel,
   Column,
   Flex,
   Heading,
   SmartLink,
   Text,
 } from "@once-ui-system/core";
+import Image from "next/image";
 
 interface ProjectCardProps {
   href: string;
@@ -19,6 +19,7 @@ interface ProjectCardProps {
   description: string;
   avatars: { src: string }[];
   link: string;
+  thumbnail?: string;
 }
 
 export const ProjectCard: React.FC<ProjectCardProps> = ({
@@ -29,16 +30,20 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
   description,
   avatars,
   link,
+  thumbnail,
 }) => {
   return (
     <Column fillWidth gap="m">
-      <Carousel
-        sizes="(max-width: 960px) 100vw, 960px"
-        items={images.map((image) => ({
-          slide: image,
-          alt: title,
-        }))}
-      />
+      {thumbnail && (
+        <Image
+          src={thumbnail}
+          alt={`${title} thumbnail`}
+          width={300}
+          height={300}
+          sizes="(max-width:768px) 100vw, 300px"
+          className="max-w-[300px] w-full h-auto rounded-xl mb-6"
+        />
+      )}
       <Flex
         mobileDirection="column"
         fillWidth

--- a/src/components/work/Projects.tsx
+++ b/src/components/work/Projects.tsx
@@ -1,6 +1,7 @@
 import { getPosts } from "@/app/utils/utils";
 import { Column } from "@once-ui-system/core";
 import { ProjectCard } from "@/components";
+import { projects as projectMeta } from "@/data/projects";
 
 interface ProjectsProps {
   range?: [number, number?];
@@ -19,19 +20,23 @@ export function Projects({ range }: ProjectsProps) {
 
   return (
     <Column fillWidth gap="xl" marginBottom="40" paddingX="l">
-      {displayedProjects.map((post, index) => (
-        <ProjectCard
-          priority={index < 2}
-          key={post.slug}
-          href={`work/${post.slug}`}
-          images={post.metadata.images}
-          title={post.metadata.title}
-          description={post.metadata.summary}
-          content={post.content}
-          avatars={post.metadata.team?.map((member) => ({ src: member.avatar })) || []}
-          link={post.metadata.link || ""}
-        />
-      ))}
+      {displayedProjects.map((post, index) => {
+        const meta = projectMeta.find((p) => p.slug === post.slug);
+        return (
+          <ProjectCard
+            priority={index < 2}
+            key={post.slug}
+            href={`work/${post.slug}`}
+            images={post.metadata.images}
+            title={post.metadata.title}
+            description={post.metadata.summary}
+            content={post.content}
+            avatars={post.metadata.team?.map((member) => ({ src: member.avatar })) || []}
+            link={post.metadata.link || ""}
+            thumbnail={meta?.thumbnail}
+          />
+        );
+      })}
     </Column>
   );
 }

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,24 @@
+export interface ProjectMeta {
+  slug: string;
+  title: string;
+  tagline: string;
+  thumbnail: string;
+  hero: string;
+}
+
+export const projects: ProjectMeta[] = [
+  {
+    slug: 'cleanmydesktop-pro',
+    title: 'CleanMyDesktop Pro',
+    tagline: 'One-click organizer for chaotic desktops.',
+    thumbnail: '/assets/projects/cleanmydesktop-pro/thumb@1x1.jpg',
+    hero: '/assets/projects/cleanmydesktop-pro/hero@16x9.jpg',
+  },
+  {
+    slug: 'habit-tracker',
+    title: 'Habit Tracker',
+    tagline: 'Track habits, moods & streaks',
+    thumbnail: '/assets/projects/habit-tracker/thumb@1x1.jpg',
+    hero: '/assets/projects/habit-tracker/hero@16x9.jpg',
+  },
+];


### PR DESCRIPTION
## Summary
- list project thumbnails via `src/data/projects.ts`
- show thumbnails on project cards
- display hero images on project pages

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6858ac2da7cc832d9bd589b506798246