### PR TITLE
Add scroll indicator on homepage hero

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { home, about, person, newsletter, baseURL, routes } from "@/resources";
 import { Mailchimp } from "@/components";
 import { Projects } from "@/components/work/Projects";
 import { Posts } from "@/components/blog/Posts";
+import { ScrollIndicator } from "@/components/ScrollIndicator";
 
 export default function Home() {
   return (
@@ -61,15 +62,19 @@ export default function Home() {
                     size="m"
                   />
                 )}
-                {about.title}
-              </Flex>
-            </Button>
-          </RevealFx>
-        </Column>
+              {about.title}
+            </Flex>
+          </Button>
+        </RevealFx>
+        <Flex horizontal="center">
+          <ScrollIndicator />
+        </Flex>
       </Column>
-      <RevealFx translateY="16" delay={0.6}>
-        <Projects range={[1, 1]} />
-      </RevealFx>
+    </Column>
+    <div id="about" />
+    <RevealFx translateY="16" delay={0.6}>
+      <Projects range={[1, 1]} />
+    </RevealFx>
       {routes["/blog"] && (
         <Flex fillWidth gap="24" mobileDirection="column">
           <Flex flex={1} paddingLeft="l" paddingTop="24">

--- a/src/components/ScrollIndicator.module.scss
+++ b/src/components/ScrollIndicator.module.scss
@@ -1,0 +1,17 @@
+@use "./breakpoints.scss" as breakpoints;
+
+.indicator {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--static-space-16);
+  animation: bounce 2s ease-in-out infinite;
+}
+
+@keyframes bounce {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(6px);
+  }
+}

--- a/src/components/ScrollIndicator.tsx
+++ b/src/components/ScrollIndicator.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { Icon, Flex } from "@once-ui-system/core";
+import styles from "./ScrollIndicator.module.scss";
+
+export function ScrollIndicator() {
+  return (
+    <a href="#about" className={styles.indicator} aria-hidden="true">
+      <Icon name="chevronDown" decorative size="l" />
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ScrollIndicator` component with bounce animation
- show the indicator below the main hero button
- anchor-scroll to About section using `#about`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6858ac7c8930832d9d3d345381542117