### PR TITLE
Add MDX frontmatter test for use-client files

### DIFF
--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -43,11 +43,14 @@ function getMDXFiles(dir: string): string[] {
 }
 
 function readMDXFile(filePath: string) {
-    if (!fs.existsSync(filePath)) {
-        notFound();
-    }
+  if (!fs.existsSync(filePath)) {
+    notFound();
+  }
 
-  const rawContent = fs.readFileSync(filePath, "utf-8");
+  let rawContent = fs.readFileSync(filePath, "utf-8");
+  if (rawContent.startsWith("'use client'") || rawContent.startsWith('"use client"')) {
+    rawContent = rawContent.split('\n').slice(1).join('\n');
+  }
   const { data, content } = matter(rawContent);
 
   const metadata: Metadata = {

--- a/tests/mdx.test.ts
+++ b/tests/mdx.test.ts
@@ -38,3 +38,14 @@ for (const file of mdxFiles) {
     assert.ok(data.publishedAt, 'missing publishedAt');
   });
 }
+
+test('getPosts handles use client frontmatter', () => {
+  type Post = { metadata: { publishedAt: string }; slug: string; content: string };
+  const { getPosts } = require('../src/app/utils/utils') as {
+    getPosts: (paths: string[]) => Post[];
+  };
+  const posts = getPosts(['src', 'app', 'blog', 'posts']);
+  const item = posts.find((p) => p.slug === 'cleanmydesktop-pro-roadmap');
+  assert.ok(item, 'post not found');
+  assert.ok(item.metadata.publishedAt, 'missing publishedAt');
+});


### PR DESCRIPTION
## Summary
- test `getPosts()` with a `use client` MDX file
- strip `use client` pragma when reading MDX files

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685b2aacba68832d986b20252a5ac9c2