### PR TITLE
fix(utils): handle use-client preamble

### DIFF
--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -43,16 +43,23 @@ function getMDXFiles(dir: string): string[] {
 }
 
 function readMDXFile(filePath: string) {
-    if (!fs.existsSync(filePath)) {
-        notFound();
-    }
+  if (!fs.existsSync(filePath)) {
+    notFound();
+  }
 
-  const rawContent = fs.readFileSync(filePath, "utf-8");
+  let rawContent = fs.readFileSync(filePath, "utf-8");
+  if (
+    rawContent.startsWith("'use client'") ||
+    rawContent.startsWith('"use client"')
+  ) {
+    rawContent = rawContent.split(/\r?\n/).slice(1).join("\n");
+  }
+
   const { data, content } = matter(rawContent);
 
   const metadata: Metadata = {
     title: data.title || "",
-    publishedAt: data.publishedAt,
+    publishedAt: data.publishedAt || "",
     summary: data.summary || "",
     image: data.image || "",
     images: data.images || [],


### PR DESCRIPTION
## Summary
- support MDX files that begin with a `'use client'` statement
- default `metadata.publishedAt` to an empty string if missing

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685b2aabaad8832da7ca72629f2b1c54