### PR TITLE
Fix frontmatter date parsing

### DIFF
--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -63,9 +63,17 @@ function readMDXFile(filePath: string) {
 
   const { data, content } = matter(rawContent);
 
+  const dateVal = data.publishedAt;
+  let publishedAt = "";
+  if (typeof dateVal === "string") {
+    publishedAt = dateVal;
+  } else if (dateVal instanceof Date && !Number.isNaN(dateVal.valueOf())) {
+    publishedAt = dateVal.toISOString().slice(0, 10);
+  }
+
   const metadata: Metadata = {
     title: data.title || "",
-    publishedAt: data.publishedAt || "",
+    publishedAt,
     summary: data.summary || "",
     image: data.image || "",
     images: data.images || [],

--- a/tests/mdx.test.ts
+++ b/tests/mdx.test.ts
@@ -36,6 +36,11 @@ for (const file of mdxFiles) {
 
     assert.ok(data.title, 'missing title');
     assert.ok(data.publishedAt, 'missing publishedAt');
+    assert.equal(
+      typeof data.publishedAt,
+      'string',
+      'publishedAt must be a string'
+    );
   });
 }
 
@@ -48,4 +53,9 @@ test('getPosts handles use client frontmatter', () => {
   const item = posts.find((p) => p.slug === 'cleanmydesktop-pro-roadmap');
   assert.ok(item, 'post not found');
   assert.ok(item.metadata.publishedAt, 'missing publishedAt');
+  assert.equal(
+    typeof item.metadata.publishedAt,
+    'string',
+    'publishedAt must be a string'
+  );
 });


### PR DESCRIPTION
## Summary
- normalize `publishedAt` as an ISO string in `readMDXFile`
- ensure unit tests require `publishedAt` to be a string

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685b3f75c584832db835faff507b62f2