### PR TITLE
Fix Node test compatibility

### DIFF
--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -6,7 +6,7 @@
     "outDir": "dist-test",
 
     /* Node test-runner friendly */
-    "module": "CommonJS",
+    "module": "ESNext",
     "moduleResolution": "node",
     "types": ["node"]
   },


### PR DESCRIPTION
## Summary
- compile tests to ES modules so Node's test runner can import them

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6864860f7e9c832dbecdcdc0d1510c6f