### PR TITLE
Update workflows to use pnpm 9.1.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,20 @@
 # .github/workflows/build.yml
 name: Build
 on: [push, pull_request]
+env:
+  NODE_VERSION: '20'
+  PNPM_VERSION: '9.1.1'
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-        with: { version: 8 }
+      - name: Setup pnpm + Node
+        uses: pnpm/action-setup@v2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+          run_install: false
+      - run: pnpm --version
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,20 @@
 # .github/workflows/lint.yml
 name: Lint & Type-check
 on: [push, pull_request]
+env:
+  NODE_VERSION: '20'
+  PNPM_VERSION: '9.1.1'
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-        with: { version: 8 }
+      - name: Setup pnpm + Node
+        uses: pnpm/action-setup@v2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+          run_install: false
+      - run: pnpm --version
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint && pnpm type-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,20 @@
 # .github/workflows/test.yml
 name: Unit Tests
 on: [push, pull_request]
+env:
+  NODE_VERSION: '20'
+  PNPM_VERSION: '9.1.1'
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-        with: { version: 8 }
+      - name: Setup pnpm + Node
+        uses: pnpm/action-setup@v2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+          run_install: false
+      - run: pnpm --version
       - run: pnpm install --frozen-lockfile
       - run: pnpm test


### PR DESCRIPTION
## Summary
- align build, lint and test workflows with CI
- use Node 20 and pnpm 9.1.1 in each workflow
- verify installed pnpm version

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686487923260832da938305f99b3b0a6