### PR TITLE
Add schedule modal to about page

### DIFF
--- a/src/app/about/ScheduleCallModal.tsx
+++ b/src/app/about/ScheduleCallModal.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog, IconButton, Button, Flex, Text } from "@once-ui-system/core";
+
+export default function ScheduleCallModal() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <IconButton
+        onClick={() => setOpen(true)}
+        data-border="rounded"
+        variant="secondary"
+        icon="chevronRight"
+      />
+      <Dialog
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        title="Coming soon"
+        description={
+          <Text variant="body-default-s" onBackground="neutral-weak">
+            Calendar scheduling will be available soon.
+          </Text>
+        }
+        footer={
+          <Flex paddingTop="12" horizontal="end">
+            <Button onClick={() => setOpen(false)} variant="primary">
+              Close
+            </Button>
+          </Flex>
+        }
+      />
+    </>
+  );
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@once-ui-system/core";
 import { baseURL, about, person, social } from "@/resources";
 import TableOfContents from "@/components/about/TableOfContents";
+import ScheduleCallModal from "./ScheduleCallModal";
 import styles from "@/components/about/about.module.scss";
 import React from "react";
 
@@ -130,12 +131,7 @@ export default function About() {
               >
                 <Icon paddingLeft="12" name="calendar" onBackground="brand-weak" />
                 <Flex paddingX="8">Schedule a call</Flex>
-                <IconButton
-                  href={about.calendar.link}
-                  data-border="rounded"
-                  variant="secondary"
-                  icon="chevronRight"
-                />
+                <ScheduleCallModal />
               </Flex>
             )}
             <Heading className={styles.textAlign} variant="display-strong-xl">

--- a/src/resources/content.js
+++ b/src/resources/content.js
@@ -10,7 +10,7 @@ const person = {
   avatar: '/images/avatar.jpg',
   email: 'example@gmail.com',
   location: 'America/Chicago', // Expecting the IANA time zone identifier, e.g., 'Europe/Vienna'
-  languages: ['English', 'Bahasa'], // optional: Leave the array empty if you don't want to display languages
+  languages: ['English'], // optional: Leave the array empty if you don't want to display languages
 };
 
 const newsletter = {


### PR DESCRIPTION
## Summary
- set supported language to English only
- add `ScheduleCallModal` client component
- use modal-trigger button on About page

## Testing
- `pnpm lint --fix`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68695cee9f0c832d92c707292a4f5a94