### PR TITLE
Automate deploys via SSH

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,5 +29,6 @@ jobs:
         script: |
           cd /var/www/jakelawrence.io
           git pull origin main
-          pnpm install --frozen-lockfile
+          pnpm install --silent
+          pnpm build
           pm2 restart portfolio

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ description: "One‑sentence summary for SEO & OG"
 ## CI/CD Overview
 
 1. **GitHub Actions** — lints, tests, builds on every push to `main`.
-2. **Deploy Job** — if build passes, hits secure webhook on DigitalOcean droplet.
-3. **Droplet Script** — pulls `main`, runs `pnpm install && pnpm build`, reloads PM2.
+2. **Deploy Job** — if build passes, connects over SSH to the droplet.
+3. **Droplet Script** — pulls `main`, runs `pnpm install && pnpm build`, then reloads PM2.
 4. **NGINX** proxies `https://` traffic to the PM2 process on :3000.
 
 Infrastructure details live in [`infra-playbook.md`](infra-playbook.md).

--- a/docs/infra-playbook.md
+++ b/docs/infra-playbook.md
@@ -235,8 +235,8 @@ Log rotation already provided by `pm2-logrotate` (installed automatically).
 
 ```text
 1. Commit & push → origin/main
-2. curl -s "https://jakelawrence.io/deploy?secret=SUPERSECRET123"
-3. journalctl -fu webhook   # optional tail
+2. GitHub Action connects via SSH and runs `/opt/deploy/portfolio.sh`
+3. journalctl -fu webhook   # optional tail (manual webhook still works)
 ```
 
 Typical deploy time: **\~50 s** (install ≈ 20 s, build ≈ 25 s, reload < 1 s).
@@ -259,7 +259,7 @@ Typical deploy time: **\~50 s** (install ≈ 20 s, build ≈ 25 s, rel
 
 * Move runtime to unprivileged `deploy` user instead of `root`.
 * Put Cloudflare in front for DDoS & caching.
-* Turn deploy script into GitHub Action (SSH) to remove public webhook.
+* Public webhook replaced by GitHub Action that runs the deploy script over SSH.
 * Migrate to Docker (next‑on‑pages, Caddy, etc.) if containerisation is needed.
 
 ---
@@ -274,7 +274,7 @@ Typical deploy time: **\~50 s** (install ≈ 20 s, build ≈ 25 s, rel
 
 ---
 
-Happy shipping!  One command and you’re live:
+Happy shipping!  Manual redeploys are still possible:
 
 ```bash
 curl -s "https://jakelawrence.io/deploy?secret=SUPERSECRET123"

--- a/infra-playbook.md
+++ b/infra-playbook.md
@@ -227,15 +227,14 @@ pm2 startup systemd -u root --hp /root
 %% CI → Deploy overview
 flowchart TD
   A[Push<br/>main] --> B[CI job<br/>lint·test·build]
-  B -->|✓| C[Deploy job<br/>curl /deploy?secret=…]
-  C --> D[Webhook<br/>9001]
-  D --> E[/opt/deploy/portfolio.sh/]
-  E --> PM2[PM2 process]
+  B -->|✓| C[Deploy job<br/>SSH → deploy script]
+  C --> D[/opt/deploy/portfolio.sh/]
+  D --> PM2[PM2 process]
   PM2 --> APP[Next.js<br/>:3000]
 ```
 
 * **CI job** – Node 20 + pnpm 10, then `lint`, `test`, `build`.
-* **Deploy job** – only runs when CI passes; `curl` hits secure webhook.
+* **Deploy job** – only runs when CI passes; uses SSH to run the deploy script.
 
 Secrets required: `WEBHOOK_URL`, `WEBHOOK_SECRET`, `DO_SSH_KEY`, `DO_HOST`.
 
@@ -262,7 +261,9 @@ Secrets required: `WEBHOOK_URL`, `WEBHOOK_SECRET`, `DO_SSH_KEY`, `DO_HOST`.
 
 ---
 
-### Quick deploy
+### Manual deploy (optional)
+
+`curl`ing the webhook still works for ad‑hoc redeploys:
 
 ```bash
 curl -s "https://jakelawrence.io/deploy?secret=SUPERSECRET123"

--- a/src/app/blog/posts/welcome-to-the-portfolio.mdx
+++ b/src/app/blog/posts/welcome-to-the-portfolio.mdx
@@ -61,17 +61,16 @@ Below is the **DAG** my CI/CD pipeline follows whenever I push to `main`.
 flowchart TD
     subgraph GitHub Actions
         LINT[Lint] --> TEST[Test] --> BUILD[Next build]
-        BUILD --> DEPLOY[cURL webhook]
+        BUILD --> DEPLOY[SSH deploy]
     end
 
-    DEPLOY --> Webhook[/Webhook 9001/]
-    Webhook --> Script[[/opt/deploy/portfolio.sh]]
+    DEPLOY --> Script[[/opt/deploy/portfolio.sh]]
     Script --> PM2[PM2 reload]
     PM2 --> NGINX[(NGINX 443)]
     NGINX --> Browser[🧑‍💻 You]
 ```
 
-* **All green?** A secure webhook hits my [DigitalOcean droplet](https://docs.digitalocean.com/products/droplets/).
+* **All green?** A GitHub Action logs into my [DigitalOcean droplet](https://docs.digitalocean.com/products/droplets/) over SSH.
 * The droplet script pulls latest, runs `pnpm build`, and reloads **PM2**.
 * **NGINX** proxies HTTPS traffic to port 3000. Zero-downtime, no drama.
 
@@ -109,7 +108,7 @@ Time dilation fees not included.
 | **[Once UI](https://once-ui.com)** | Customised theme, dark-mode              |
 | **pnpm 9.1.1**                     | Fast, deterministic installs (pinned)    |
 | **TypeScript**                     | `strict`—no `any` in production code     |
-| **CI/CD**                          | GitHub Actions → Webhook → PM2           |
+| **CI/CD**                          | GitHub Actions → SSH → PM2           |
 | **Docs**                           | [`AGENTS.md`](/AGENTS.md) (coding rules) |
 
 ---


### PR DESCRIPTION
## Summary
- rebuild and restart server in deploy workflow
- note SSH-based deploy in documentation

## Testing
- `pnpm lint`
- `npx -y node@20 --test dist-test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6869f036422c832da7258a40b2bdf3b6