### PR TITLE
Enable GFM tables in MDX rendering

### DIFF
--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -1,6 +1,7 @@
 import { MDXRemote, MDXRemoteProps } from "next-mdx-remote/rsc";
 import React, { ReactNode } from "react";
 import dynamic from "next/dynamic";
+import remarkGfm from "remark-gfm";
 
 import { 
   Heading,
@@ -189,6 +190,10 @@ type CustomMDXProps = MDXRemoteProps & {
 
 export function CustomMDX(props: CustomMDXProps) {
   return (
-    <MDXRemote {...props} components={{ ...components, ...(props.components || {}) }} />
+    <MDXRemote
+      {...props}
+      components={{ ...components, ...(props.components || {}) }}
+      options={{ mdxOptions: { remarkPlugins: [remarkGfm] } }}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- ensure MDXRemote uses `remark-gfm`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_687409a8351c832da5e7e5b92bf820f9