### PR TITLE
Improve deploy script with atomic builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,9 +26,21 @@ jobs:
         host: ${{ secrets.DO_HOST }}
         username: root
         key: ${{ secrets.DO_SSH_KEY }}
-        script: |
-          cd /var/www/jakelawrence.io
-          git pull origin main
-          pnpm install --silent
-          pnpm build
-          pm2 restart portfolio
+        script: /opt/deploy/portfolio.sh
+
+    - name: Download deploy log
+      uses: appleboy/scp-action@v0.1.4
+      if: always()
+      with:
+        host: ${{ secrets.DO_HOST }}
+        username: root
+        key: ${{ secrets.DO_SSH_KEY }}
+        source: /var/log/portfolio-deploy.log
+        target: ./deploy-log
+
+    - name: Upload deploy log
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: deploy-log
+        path: deploy-log/portfolio-deploy.log

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ description: "One‑sentence summary for SEO & OG"
 
 1. **GitHub Actions** — lints, tests, builds on every push to `main`.
 2. **Deploy Job** — if build passes, connects over SSH to the droplet.
-3. **Droplet Script** — pulls `main`, runs `pnpm install && pnpm build`, then reloads PM2.
+3. **Droplet Script** — syncs `main`, builds into `.next-temp` then swaps to `.next`, reloads PM2 and logs to `/var/log/portfolio-deploy.log`.
 4. **NGINX** proxies `https://` traffic to the PM2 process on :3000.
 
 Infrastructure details live in [`infra-playbook.md`](infra-playbook.md).

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,8 @@ const withMDX = mdx({
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Allow custom build directory via NEXT_BUILD_DIR for atomic deploys
+  distDir: process.env.NEXT_BUILD_DIR || '.next',
   // Put .md/.mdx first so they win if a slug collides with a .tsx file
   pageExtensions: ['md', 'mdx', 'ts', 'tsx'],
 

--- a/scripts/portfolio.sh
+++ b/scripts/portfolio.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Log everything for debugging
+exec > >(tee -a /var/log/portfolio-deploy.log) 2>&1
+
+REPO_DIR=/var/www/jakelawrence.io
+PNPM=/usr/local/bin/pnpm
+
+echo "🚀  Deploy started at $(date -u)"
+
+# Environment info
+echo "Working directory: $REPO_DIR"
+node --version
+"$PNPM" --version
+pm2 list
+
+# Sync code and keep previous build intact
+git -C "$REPO_DIR" fetch --all
+git -C "$REPO_DIR" reset --hard origin/main
+git -C "$REPO_DIR" clean -fd -e .next
+
+cd "$REPO_DIR"
+"$PNPM" install --silent
+
+# Build into temporary directory
+BUILD_DIR=.next-temp
+rm -rf "$BUILD_DIR"
+NEXT_BUILD_DIR="$BUILD_DIR" "$PNPM" build
+
+# Swap directories only if build succeeded
+if [ -d "$BUILD_DIR" ]; then
+  rm -rf .next.bak
+  mv .next .next.bak || true
+  mv "$BUILD_DIR" .next
+  rm -rf .next.bak
+fi
+
+# Reload or start PM2
+if pm2 describe portfolio >/dev/null 2>&1; then
+  pm2 reload portfolio --update-env
+else
+  pm2 start "$PNPM" --name portfolio --cwd "$REPO_DIR" -- start
+fi
+
+pm2 save
+
+echo "✅  Deploy finished at $(date -u)"


### PR DESCRIPTION
## Summary
- deploy script now logs to `/var/log/portfolio-deploy.log`
- build to `.next-temp` then atomically swap into `.next`
- add `NEXT_BUILD_DIR` option in `next.config.mjs`
- update docs and deploy workflow accordingly

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_687408c08304832d931a0c9e09860d33