### PR TITLE
Add AnimatedSignalPulse component

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react-icons": "^5.5.0",
     "react-masonry-css": "^1.0.16",
     "remark-gfm": "^4.0.1",
-    "sass": "^1.86.3"
+    "sass": "^1.86.3",
+    "clsx": "^2.1.1"
   },
   "devDependencies": {
     "@types/cookie": "^0.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       cookie:
         specifier: ^1.0.2
         version: 1.0.2

--- a/src/components/AnimatedSignalPulse.tsx
+++ b/src/components/AnimatedSignalPulse.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import React from 'react';
+import clsx from 'clsx';
+import TypewriterText from './TypewriterText';
+
+export interface AnimatedSignalPulseProps {
+  id: string | number;
+  label: string;
+  glow: 'gold' | 'green' | 'indigo';
+}
+
+const glowMap: Record<AnimatedSignalPulseProps['glow'], string> = {
+  gold: 'border-yellow-300 text-yellow-300 bg-yellow-300/10 shadow-[inset_0_0_4px_rgba(253,224,71,0.6)]',
+  green: 'border-green-300 text-green-300 bg-green-300/10 shadow-[inset_0_0_4px_rgba(134,239,172,0.6)]',
+  indigo: 'border-indigo-300 text-indigo-300 bg-indigo-300/10 shadow-[inset_0_0_4px_rgba(165,180,252,0.6)]',
+};
+
+export default function AnimatedSignalPulse({ id, label, glow }: AnimatedSignalPulseProps) {
+  return (
+    <div
+      className={clsx(
+        'inline-block rounded-md border px-3 py-1 font-mono text-xs',
+        glowMap[glow]
+      )}
+    >
+      <TypewriterText text={`/* ——— ${id} :: ${label} ——— */`} />
+    </div>
+  );
+}

--- a/src/components/TypewriterText.tsx
+++ b/src/components/TypewriterText.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+export interface TypewriterTextProps {
+  text: string;
+  speed?: number;
+}
+
+export default function TypewriterText({ text, speed = 15 }: TypewriterTextProps) {
+  const [displayed, setDisplayed] = useState('');
+
+  useEffect(() => {
+    let index = 0;
+    let cancelled = false;
+
+    function tick() {
+      if (cancelled) return;
+      setDisplayed(text.slice(0, index + 1));
+      if (index < text.length - 1) {
+        index += 1;
+        timer = window.setTimeout(tick, speed);
+      }
+    }
+
+    let timer = window.setTimeout(tick, speed);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [text, speed]);
+
+  return <span>{displayed}</span>;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,3 +11,5 @@ export { CustomMDX } from "@/components/mdx";
 export { default as ProjectPreview } from "@/components/work/ProjectPreview";
 export { default as Callout } from "@/components/Callout";
 export { default as Mermaid } from "@/components/Mermaid";
+export { default as TypewriterText } from "@/components/TypewriterText";
+export { default as AnimatedSignalPulse } from "@/components/AnimatedSignalPulse";


### PR DESCRIPTION
## Summary
- add a client-side `TypewriterText` helper
- add `AnimatedSignalPulse` with glow styling
- expose new components via barrel file
- install `clsx` runtime dependency for conditional classes

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68740bbcfc5c832db667b7ec2b7241ba