### PR TITLE
Fix MDX table rendering

### DIFF
--- a/src/components/MarkdownTable.tsx
+++ b/src/components/MarkdownTable.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export interface MarkdownTableProps extends React.TableHTMLAttributes<HTMLTableElement> {
+  children?: React.ReactNode;
+}
+
+export default function MarkdownTable({ children, ...props }: MarkdownTableProps) {
+  return (
+    <div style={{ overflowX: 'auto', marginTop: '8px', marginBottom: '16px' }}>
+      <table
+        {...props}
+        style={{ borderCollapse: 'collapse', borderSpacing: 0, width: '100%', minWidth: '32rem' }}
+      >
+        {children}
+      </table>
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,3 +13,4 @@ export { default as Callout } from "@/components/Callout";
 export { default as Mermaid } from "@/components/Mermaid";
 export { default as TypewriterText } from "@/components/TypewriterText";
 export { default as AnimatedSignalPulse } from "@/components/AnimatedSignalPulse";
+export { default as MarkdownTable } from "@/components/MarkdownTable";

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -14,6 +14,7 @@ import {
 import { CodeBlock } from "@once-ui-system/core";
 import { TextProps } from "@once-ui-system/core";
 import { MediaProps } from "@once-ui-system/core";
+import MarkdownTable from "@/components/MarkdownTable";
 
 type CustomLinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
   href: string;
@@ -163,7 +164,7 @@ const components = {
   a: CustomLink as any,
   code: createInlineCode as any,
   pre: createCodeBlock as any,
-  table: dynamic(() => import('@once-ui-system/core').then(mod => mod.Table)) as any,
+  table: MarkdownTable as any,
   Heading,
   Text,
   CodeBlock,


### PR DESCRIPTION
## Summary
- add `MarkdownTable` component for simple MDX tables
- wire table tag in mdx renderer to use `MarkdownTable`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_687413275ba4832d9729957dd69a9d9f