### PR TITLE
Add header image to Habit Tracker post

### DIFF
--- a/src/app/blog/posts/habit-tracker.mdx
+++ b/src/app/blog/posts/habit-tracker.mdx
@@ -4,8 +4,15 @@ title: "Habit Tracker: Transforming Daily Habits into Meaningful Progress"
 publishedAt: "2025-07-05"
 summary: "From struggling with distractions to finding focus, Habit Tracker was born out of the need for a simple, effective tool to track habits, moods, and journaling, especially for those managing ADHD."
 tag: "Habit Tracker"
+image: "https://imgur.com/a/85wOyRD?auto=format&fit=crop&w=1200&q=60"
 
 ---
+
+<Media
+  src="https://imgur.com/a/85wOyRD?auto=format&fit=crop&w=1200&q=60"
+  alt="Screenshot of Habit Tracker"
+  radius="l"
+/>
 
 **The Struggle of Staying On Track**
 


### PR DESCRIPTION
## Summary
- add main blog image for Habit Tracker post
- display same image at top of the post with rounded corners

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_687422276d0c832dbd73af80bb863667