### PR TITLE
Fix blog pulse headers

### DIFF
--- a/src/app/blog/posts/welcome-to-the-portfolio.mdx
+++ b/src/app/blog/posts/welcome-to-the-portfolio.mdx
@@ -8,15 +8,13 @@ tags: ["welcome", "overview"]
 
 import Image from "next/image";
 import Callout from "@/components/Callout";
-import { AnimatedSignalPulse } from "@/components";
+import { PulseHeader } from "@/components";
 
 /* ---------------------------------------------------------
    1  Opening Pulse
 --------------------------------------------------------- */
 
-<div className="mt-10 mb-4">
-  <AnimatedSignalPulse id="0x01" label="Opening Pulse" glow="gold" />
-</div>
+<PulseHeader id="0x01" label="Opening Pulse" glow="gold" />
 
 # 👋 Hey there — Jake here!
 
@@ -35,9 +33,7 @@ Peek at <a href="https://github.com/jake0lawrence/portfolio">the repo →</a>
 
 ---
 
-<div className="mt-10 mb-4">
-  <AnimatedSignalPulse id="0x02" label="Content Constellation" glow="indigo" />
-</div>
+<PulseHeader id="0x02" label="Content Constellation" glow="indigo" />
 
 ```mermaid
 flowchart LR
@@ -60,9 +56,7 @@ flowchart LR
 
 ---
 
-<div className="mt-10 mb-4">
-  <AnimatedSignalPulse id="0x03" label="Build Pipeline" glow="green" />
-</div>
+<PulseHeader id="0x03" label="Build Pipeline" glow="green" />
 
 Below is the **DAG** my CI/CD pipeline follows whenever I push to `main`.
 
@@ -87,7 +81,7 @@ Want the gritty details? See the **[`infra-playbook.md`](/infra-playbook.md)**.
 
 ---
 
-## 4  MDX Everywhere ✨
+<PulseHeader id="0x06" label="MDX Everywhere" glow="green" />
 
 All posts, chapters, and case studies are plain **MDX**. Example front-matter:
 
@@ -109,9 +103,7 @@ Time dilation fees not included.
 
 ---
 
-<div className="mt-10 mb-4">
-  <AnimatedSignalPulse id="0x04" label="Stack Trace Log" glow="gold" />
-</div>
+<PulseHeader id="0x04" label="Stack Trace Log" glow="gold" />
 
 | Layer                              | Highlights                               |
 | ---------------------------------- | ---------------------------------------- |
@@ -124,9 +116,7 @@ Time dilation fees not included.
 
 ---
 
-<div className="mt-10 mb-4">
-  <AnimatedSignalPulse id="0x05" label="Signal: What’s Next?" glow="indigo" />
-</div>
+<PulseHeader id="0x05" label="Signal: What’s Next?" glow="indigo" />
 
 * **AI-narrated audio** for every blog post
 * **PR preview subdomain**
@@ -136,7 +126,7 @@ Time dilation fees not included.
 
 ---
 
-## 7  Thanks for Dropping By
+<PulseHeader id="0x07" label="Thanks for Dropping By" glow="gold" />
 
 Whether you’re a potential client, future employer, or fellow night-owl tinkerer—explore, fork the repo, or just read a chapter of *The Liminal* before bed (sleep tight!).
 

--- a/src/components/PulseHeader.tsx
+++ b/src/components/PulseHeader.tsx
@@ -1,0 +1,16 @@
+import AnimatedSignalPulse from "@/components/AnimatedSignalPulse";
+
+interface PulseHeaderProps {
+  id: string | number;
+  label: string;
+  glow: "gold" | "green" | "indigo";
+  className?: string;
+}
+
+export default function PulseHeader({ className = "mt-10 mb-4", ...props }: PulseHeaderProps) {
+  return (
+    <div className={className}>
+      <AnimatedSignalPulse {...props} />
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,4 +13,5 @@ export { default as Callout } from "@/components/Callout";
 export { default as Mermaid } from "@/components/Mermaid";
 export { default as TypewriterText } from "@/components/TypewriterText";
 export { default as AnimatedSignalPulse } from "@/components/AnimatedSignalPulse";
+export { default as PulseHeader } from "@/components/PulseHeader";
 export { default as MarkdownTable } from "@/components/MarkdownTable";

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -183,6 +183,7 @@ const components = {
   SmartLink: dynamic(() => import("@once-ui-system/core").then(mod => mod.SmartLink)),
   Callout: dynamic(() => import("@/components/Callout")),
   Mermaid: dynamic(() => import("@/components/Mermaid")),
+  PulseHeader: dynamic(() => import("@/components/PulseHeader")),
   AnimatedSignalPulse: dynamic(() => import("@/components/AnimatedSignalPulse")),
 };
 

--- a/tests/table.test.ts
+++ b/tests/table.test.ts
@@ -31,7 +31,7 @@ test('welcome post table renders', () => {
     useMDXComponents: () => ({
       Callout: () => null,
       Image: () => null,
-      AnimatedSignalPulse: () => null,
+      PulseHeader: () => null,
     }),
   });
 


### PR DESCRIPTION
## Summary
- replace remaining Markdown headers in welcome post with `<PulseHeader>` wrappers
- add reusable `<PulseHeader>` component
- export new component via barrel and MDX setup
- adjust test to use `PulseHeader`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_687423736ff4832d95c11367d4d88ab5