### PR TITLE
Update The Liminal card on Books page

### DIFF
--- a/src/app/books/TheLiminalCard.tsx
+++ b/src/app/books/TheLiminalCard.tsx
@@ -5,15 +5,13 @@ import { Column, Flex, Heading, Media, SmartLink, Text } from '@once-ui-system/c
 interface TheLiminalCardProps {
   cover: string;
   synopsis: string;
-  buyLink: string;
-  sampleLink: string;
+  readLink: string;
 }
 
 export default function TheLiminalCard({
   cover,
   synopsis,
-  buyLink,
-  sampleLink,
+  readLink,
 }: TheLiminalCardProps) {
   return (
     <Column gap="m" padding="24" radius="l" border="neutral-alpha-weak" fillWidth>
@@ -25,11 +23,8 @@ export default function TheLiminalCard({
         {synopsis}
       </Text>
       <Flex gap="24" wrap>
-        <SmartLink href={buyLink} prefixIcon="book">
-          <Text variant="body-default-s">Buy</Text>
-        </SmartLink>
-        <SmartLink href={sampleLink} prefixIcon="document">
-          <Text variant="body-default-s">Sample</Text>
+        <SmartLink href={readLink} prefixIcon="book">
+          <Text variant="body-default-s">Read</Text>
         </SmartLink>
       </Flex>
     </Column>

--- a/src/app/books/page.tsx
+++ b/src/app/books/page.tsx
@@ -7,10 +7,9 @@ export default function Books() {
       <Heading variant="display-strong-s">Books</Heading>
       <Grid columns="3" mobileColumns="1">
         <TheLiminalCard
-          cover="/images/projects/project-01/image-01.jpg"
-          synopsis="A speculative fiction novel about crossing realities."
-          buyLink="#"
-          sampleLink="#"
+          cover="https://i.imgur.com/ixuC2W8h.jpg"
+          synopsis="In the darkness between dimensions, something ancient is waking. The Liminal is a sci-fi horror descent into fractured time, shifting realities, and a voice that isn’t yours."
+          readLink="https://books.jakelawrence.io/2/the-liminal"
         />
       </Grid>
     </Column>


### PR DESCRIPTION
## Summary
- update `TheLiminalCard` to show a single Read link
- update Books page with new cover image, description and URL

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6874246a48c4832da6e23d3c821a5288