### PR TITLE
Add smoke tests for pages and components

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "eslint": "^9.25.0",
     "eslint-config-next": "15.3.4",
     "jsdom": "26.1.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "tsconfig-paths": "^3.15.0"
   },
   "packageManager": "pnpm@9.1.1+sha512.14e915759c11f77eac07faba4d019c193ec8637229e62ec99eefb7cf3c3b75c64447882b7c485142451ee3a6b408059cdfb7b7fa0341b975f12d0f7629c71195"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       jsdom:
         specifier: 26.1.0
         version: 26.1.0
+      tsconfig-paths:
+        specifier: ^3.15.0
+        version: 3.15.0
       typescript:
         specifier: ^5.8.3
         version: 5.8.3

--- a/tests/components.test.ts
+++ b/tests/components.test.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const indexPath = path.join(process.cwd(), 'src/components/index.ts');
+const lines = fs.readFileSync(indexPath, 'utf8').split('\n');
+
+for (const line of lines) {
+  const match = line.match(/export\s+\{\s*(?:default\s+as\s+)?(\w+)\s*\}\s*from\s+\"(.+)\"/);
+  if (!match) continue;
+  const [, name, spec] = match;
+  const rel = spec.replace(/^@\//, '');
+  const tsPathTsx = path.join(process.cwd(), 'src', rel + '.tsx');
+  const tsPathTs = path.join(process.cwd(), 'src', rel + '.ts');
+  const filePath = fs.existsSync(tsPathTsx) ? tsPathTsx : tsPathTs;
+  test(`component file ${rel} exports ${name}`, () => {
+    const source = fs.readFileSync(filePath, 'utf8');
+    const regex = new RegExp(
+      `export (?:const|function)\\s+${name}|export\\s+\\{\\s*${name}\\s*\\}|export default`
+    );
+    assert.match(source, regex);
+  });
+}

--- a/tests/pages.test.ts
+++ b/tests/pages.test.ts
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+function getPageFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...getPageFiles(full));
+    } else if (entry.isFile() && entry.name === 'page.tsx') {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+const pages = getPageFiles(path.join(process.cwd(), 'src/app'));
+
+for (const file of pages) {
+  const rel = path.relative(process.cwd(), file);
+  test(`page ${rel} has default export`, () => {
+    const source = fs.readFileSync(file, 'utf8');
+    assert.match(source, /export default/);
+  });
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -8,6 +8,7 @@
     /* Node test-runner friendly */
     "module": "ESNext",
     "moduleResolution": "node",
+    "jsx": "react-jsx",
     "types": ["node"]
   },
 


### PR DESCRIPTION
## Summary
- ensure all page routes have a default export
- verify component barrel exports match source files
- support jsx output in test build
- include tsconfig-paths as a dev dependency for completeness

## Testing
- `pnpm lint --fix`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6878030ae9b4832d8df9219a00ae248f