### PR TITLE
fix(deploy): clear existing PM2 process before start

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ description: "One‑sentence summary for SEO & OG"
 
 1. **GitHub Actions** — lints, tests, builds on every push to `main`.
 2. **Deploy Job** — if build passes, connects over SSH to the droplet.
-3. **Droplet Script** — syncs `main`, builds into `.next-temp` then swaps to `.next`, reloads PM2 and logs to `/var/log/portfolio-deploy.log`.
+3. **Droplet Script** — syncs `main`, builds into `.next-temp` then swaps to `.next`, deletes any existing PM2 process named `portfolio` before starting it and logs to `/var/log/portfolio-deploy.log`.
 4. **NGINX** proxies `https://` traffic to the PM2 process on :3000.
 
 Infrastructure details live in [`infra-playbook.md`](infra-playbook.md).

--- a/docs/infra-playbook.md
+++ b/docs/infra-playbook.md
@@ -218,10 +218,9 @@ fi
 
 # 5) Reload or start PM2
 if pm2 describe portfolio >/dev/null 2>&1; then
-  pm2 reload portfolio --update-env
-else
-  pm2 start "$PNPM" --name portfolio --cwd "$REPO_DIR" -- start
+  pm2 delete portfolio
 fi
+pm2 start "$PNPM" --name portfolio --cwd "$REPO_DIR" -- start
 
 pm2 save
 
@@ -256,7 +255,7 @@ Log rotation already provided by `pm2-logrotate` (installed automatically).
 3. journalctl -fu webhook   # optional tail (manual webhook still works)
 ```
 
-Typical deploy time: **\~50 s** (install ≈ 20 s, build ≈ 25 s, reload < 1 s).
+Typical deploy time: **\~50 s** (install ≈ 20 s, build ≈ 25 s, restart < 1 s).
 
 ---
 
@@ -285,6 +284,7 @@ Typical deploy time: **\~50 s** (install ≈ 20 s, build ≈ 25 s, rel
 
 | Date (UTC)     | Note                                                                                                           |
 | -------------- | -------------------------------------------------------------------------------------------------------------- |
+| **2025‑07‑16** | Deploy script deletes any existing PM2 process before starting to avoid `EADDRINUSE` errors. |
 | **2025‑06‑23** | Refactored deploy: moved script to `/opt/deploy`, switched to pnpm, added `.next` keep‑alive, auto PM2 reload. |
 | **2025‑06‑22** | Initial production launch, webhook + NGINX TLS, Node 20, PM2 logrotate.                                        |
 | **2025‑06‑21** | Droplet created, DNS & firewall, first manual Next.js build.                                                   |

--- a/scripts/portfolio.sh
+++ b/scripts/portfolio.sh
@@ -38,10 +38,9 @@ fi
 
 # Reload or start PM2
 if pm2 describe portfolio >/dev/null 2>&1; then
-  pm2 reload portfolio --update-env
-else
-  pm2 start "$PNPM" --name portfolio --cwd "$REPO_DIR" -- start
+  pm2 delete portfolio
 fi
+pm2 start "$PNPM" --name portfolio --cwd "$REPO_DIR" -- start
 
 pm2 save
 


### PR DESCRIPTION
## Summary
- update portfolio deploy script to delete any running `portfolio` PM2 process before starting
- document the new PM2 restart behaviour in the infra playbook
- update README deployment overview accordingly

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- manual PM2 start/delete to verify no `EADDRINUSE` errors

------
https://chatgpt.com/codex/tasks/task_e_68781b192958832dad336d55b757e47a